### PR TITLE
fix(jsdoc): Remove depricated jsdoc rules

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -49,7 +49,6 @@ module.exports = {
         'no-unsafe-negation': 'error', // disallow negating the left operand of relational operators https://eslint.org/docs/rules/no-unsafe-negation
         'require-atomic-updates': 'off', // Disallow assignments that can lead to race conditions due to usage of await or yield https://eslint.org/docs/rules/require-atomic-updates
         'use-isnan': 'error', // disallow comparisons with the value NaN https://eslint.org/docs/rules/use-isnan
-        'valid-jsdoc': 'off', // ensure JSDoc comments are valid https://eslint.org/docs/rules/valid-jsdoc
         'valid-typeof': ['error', {requireStringLiterals: true}] // ensure that the results of typeof are compared against a valid string https://eslint.org/docs/rules/valid-typeof
     }
 };

--- a/rules/style.js
+++ b/rules/style.js
@@ -327,7 +327,6 @@ module.exports = {
             'single',
             {avoidEscape: true}
         ], // specify whether double or single quotes should be used
-        'require-jsdoc': 'off', // do not require jsdoc https://eslint.org/docs/rules/require-jsdoc
         semi: ['error', 'always'], // require or disallow use of semicolons instead of ASI https://eslint.org/docs/rules/semi
         'semi-spacing': [
             'error',


### PR DESCRIPTION
We already using the community-supported eslint-plugin-jsdoc plugin as replacement